### PR TITLE
test: Fix DataDog config reloading (DBTP-2165)

### DIFF
--- a/tests/test_django_log_formatter.py
+++ b/tests/test_django_log_formatter.py
@@ -1,9 +1,9 @@
 import json
 import logging
 import os
-from importlib import reload
 from importlib.metadata import distribution
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import ddtrace
 import pytest
@@ -228,13 +228,11 @@ class TestASIMFormatter:
         assert TEST_LAST_NAME in raw_log
 
     @patch("ddtrace.trace.tracer.current_span")
-    def test_logs_log_datadog_required_values_when_env_vars_set(
-        self, mock_ddtrace_span, caplog
-    ):
+    def test_logs_log_datadog_required_values_when_env_vars_set(self, mock_ddtrace_span, caplog):
         os.environ["DD_ENV"] = "test"
         os.environ["DD_SERVICE"] = "django-service"
         os.environ["DD_VERSION"] = "1.0.0"
-        reload(ddtrace)
+        ddtrace.config = ddtrace.settings._config.Config()
 
         mock_ddtrace_span_response = MagicMock()
         mock_ddtrace_span_response.trace_id = 5735492756521486600
@@ -254,7 +252,7 @@ class TestASIMFormatter:
         os.environ.pop("DD_ENV")
         os.environ.pop("DD_SERVICE")
         os.environ.pop("DD_VERSION")
-        reload(ddtrace)
+        ddtrace.config = ddtrace.settings._config.Config()
 
     @patch("ddtrace.trace.tracer.current_span")
     def test_logs_log_datadog_required_values_when_env_vars_not_set(
@@ -402,7 +400,7 @@ class TestASIMFormatter:
         logger.addHandler(TestHandler(records_list=[]))
         message_content = "testing 123"
         logger.debug(
-            "Test log message: %s", 
+            "Test log message: %s",
             message_content,
             extra={
                 "request": request,


### PR DESCRIPTION
The reload method doesn't appear to cause the config to be redetected when using a more modern version of the ddtrace library.

Instead reinstantiate the object manually which was having the same effect as the previous reload method.

Addresses [DBTP-2165](https://uktrade.atlassian.net/browse/DBTP-2165)

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base


[DBTP-2165]: https://uktrade.atlassian.net/browse/DBTP-2165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ