### PR TITLE
fix: Output date/time fields with explicit timezone (off-ticket)

### DIFF
--- a/django_log_formatter_asim/__init__.py
+++ b/django_log_formatter_asim/__init__.py
@@ -1,8 +1,9 @@
 import json
 import logging
-from datetime import datetime
-from importlib.metadata import distribution
 import os
+from datetime import datetime
+from datetime import timezone
+from importlib.metadata import distribution
 
 import ddtrace
 from ddtrace.trace import tracer
@@ -70,7 +71,7 @@ class ASIMRootFormatter:
 
     def get_log_dict(self):
         record = self.record
-        log_time = datetime.utcfromtimestamp(record.created).isoformat()
+        log_time = datetime.fromtimestamp(record.created, timezone.utc).isoformat()
         log_dict = {
             # Event fields...
             "EventMessage": record.getMessage(),

--- a/tests/test_django_log_formatter.py
+++ b/tests/test_django_log_formatter.py
@@ -61,7 +61,7 @@ class TestASIMFormatter:
 
         output = self._get_json_log_entry(caplog)
         self._assert_base_fields(
-            expected_log_time="2023-10-17T07:15:30",
+            expected_log_time="2023-10-17T07:15:30+00:00",
             logger_name=logger_name,
             output=output,
         )
@@ -78,7 +78,7 @@ class TestASIMFormatter:
 
         output = self._get_json_log_entry(caplog)
         self._assert_base_fields(
-            expected_log_time="2023-10-17T07:15:30",
+            expected_log_time="2023-10-17T07:15:30+00:00",
             logger_name=logger_name,
             output=output,
         )


### PR DESCRIPTION
Removes any ambiguity around what the timezone the time is for.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base
