### PR TITLE
fix: Find the clients IP address as opposed to any reverse proxy (DBTP-2201)

### DIFF
--- a/django_log_formatter_asim/__init__.py
+++ b/django_log_formatter_asim/__init__.py
@@ -201,14 +201,6 @@ class ASIMRequestFormatter(ASIMRootFormatter):
             http_user_agent = request.META.get("HTTP_USER_AGENT", None)
         return http_user_agent
 
-    def _get_ip_address(self, request):
-        # Import here as ipware uses settings
-        from ipware import get_client_ip
-
-        client_ip, is_routable = get_client_ip(request)
-        return client_ip or "Unknown"
-
-
 ASIM_FORMATTERS = {
     "root": ASIMRootFormatter,
     "django.request": ASIMRequestFormatter,

--- a/django_log_formatter_asim/events/authentication.py
+++ b/django_log_formatter_asim/events/authentication.py
@@ -12,6 +12,7 @@ from .common import Result
 from .common import Server
 from .common import Severity
 from .common import _default_severity
+from .common import _get_client_ip_address
 
 
 class AuthenticationEvent(str, Enum):
@@ -126,13 +127,13 @@ def log_authentication(
 
     if "hostname" in server:
         log["DvcHostname"] = server["hostname"]
-    elif hasattr(request, "environ") and "SERVER_NAME" in request.environ:
-        log["DvcHostname"] = request.environ["SERVER_NAME"]
+    elif "SERVER_NAME" in request.META:
+        log["DvcHostname"] = request.META["SERVER_NAME"]
 
     if "ip_address" in client:
         log["SrcIpAddr"] = client["ip_address"]
-    elif hasattr(request, "environ") and "REMOTE_ADDR" in request.environ:
-        log["SrcIpAddr"] = request.environ.get("REMOTE_ADDR")
+    elif client_ip := _get_client_ip_address(request):
+        log["SrcIpAddr"] = client_ip
 
     if "role" in user:
         log["ActorUserType"] = user["role"]

--- a/django_log_formatter_asim/events/common.py
+++ b/django_log_formatter_asim/events/common.py
@@ -2,6 +2,8 @@ from enum import Enum
 from typing import Optional
 from typing import TypedDict
 
+from django.http import HttpRequest
+
 
 class Result(str, Enum):
     Success = "Success"
@@ -40,3 +42,11 @@ class Server(TypedDict):
 
 def _default_severity(result: Result) -> Severity:
     return Severity.Informational if result == Result.Success else Severity.Medium
+
+
+def _get_client_ip_address(request: HttpRequest) -> Optional[str]:
+    # Import here as ipware uses settings
+    from ipware import get_client_ip
+
+    client_ip, _ = get_client_ip(request)
+    return client_ip

--- a/django_log_formatter_asim/events/file_activity.py
+++ b/django_log_formatter_asim/events/file_activity.py
@@ -12,6 +12,7 @@ from .common import Result
 from .common import Server
 from .common import Severity
 from .common import _default_severity
+from .common import _get_client_ip_address
 
 
 class FileActivityEvent(str, Enum):
@@ -167,13 +168,13 @@ def log_file_activity(
 
     if "hostname" in server:
         log["DvcHostname"] = server["hostname"]
-    elif hasattr(request, "environ") and "SERVER_NAME" in request.environ:
-        log["DvcHostname"] = request.environ["SERVER_NAME"]
+    elif "SERVER_NAME" in request.META:
+        log["DvcHostname"] = request.META["SERVER_NAME"]
 
     if "ip_address" in client:
         log["SrcIpAddr"] = client["ip_address"]
-    elif hasattr(request, "environ") and "REMOTE_ADDR" in request.environ:
-        log["SrcIpAddr"] = request.environ.get("REMOTE_ADDR")
+    elif client_ip := _get_client_ip_address(request):
+        log["SrcIpAddr"] = client_ip
 
     if "username" in user:
         log["ActorUsername"] = user["username"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -221,6 +221,21 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "django-ipware"
+version = "7.0.1"
+description = "A Django application to retrieve user's IP address"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "django-ipware-7.0.1.tar.gz", hash = "sha256:d9ec43d2bf7cdf216fed8d494a084deb5761a54860a53b2e74346a4f384cff47"},
+    {file = "django_ipware-7.0.1-py2.py3-none-any.whl", hash = "sha256:db16bbee920f661ae7f678e4270460c85850f03c6761a4eaeb489bdc91f64709"},
+]
+
+[package.dependencies]
+python-ipware = ">=2.0.3"
+
+[[package]]
 name = "envier"
 version = "0.6.1"
 description = "Python application configuration via the environment"
@@ -532,6 +547,21 @@ files = [
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "python-ipware"
+version = "3.0.0"
+description = "A Python package to retrieve user's IP address"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "python_ipware-3.0.0-py3-none-any.whl", hash = "sha256:fc936e6e7ec9fcc107f9315df40658f468ac72f739482a707181742882e36b60"},
+    {file = "python_ipware-3.0.0.tar.gz", hash = "sha256:9117b1c4dddcb5d5ca49e6a9617de2fc66aec2ef35394563ac4eecabdf58c062"},
+]
+
+[package.extras]
+dev = ["coverage[toml]", "coveralls (>=3.3,<4.0)", "ruff", "twine"]
 
 [[package]]
 name = "pyyaml"
@@ -850,4 +880,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4"
-content-hash = "c01101edf704b64c098588d89a869fdffcc6c309695029d1faa33c055202e525"
+content-hash = "3dd0cdd502953429a7c96cabc43a67b0d3eae731efebb311ac4569530033c0b6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ django = [
     { version = ">=3,<6", python = ">=3.10,<4" },
 ]
 ddtrace = "^3.2.1"
+django-ipware = "^7.0.1"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.5.0"

--- a/tests/events/common_events.py
+++ b/tests/events/common_events.py
@@ -5,8 +5,9 @@ from collections import namedtuple
 
 
 class CommonEvents(ABC):
-    def test_does_not_populate_request_environ_fields_when_environ_is_not_provided(self, capsys):
-        wsgi_request = namedtuple("Request", ["user", "session"])(
+    def test_does_not_populate_srcip_and_dvchostname_when_META_is_not_provided(self, capsys):
+        wsgi_request = namedtuple("Request", ["META", "user", "session"])(
+            {},
             namedtuple("User", ["username"])(None),
             namedtuple("Session", ["session_key"])(None),
         )

--- a/tests/events/conftest.py
+++ b/tests/events/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 @pytest.fixture()
 def wsgi_request():
-    return namedtuple("Request", ["environ", "user", "session"])(
+    return namedtuple("Request", ["META", "user", "session"])(
         {"REMOTE_ADDR": "192.168.1.101", "SERVER_NAME": "WebServer.local"},
         namedtuple("User", ["username"])("Adrian"),
         namedtuple("Session", ["session_key"])("def456"),

--- a/tests/events/test_common.py
+++ b/tests/events/test_common.py
@@ -1,0 +1,13 @@
+from collections import namedtuple
+
+from django_log_formatter_asim.events.common import _get_client_ip_address
+
+
+def test_get_client_ip_address_uses_X_FORWARDED_FOR():
+    wsgi_request = namedtuple("Request", ["META"])(
+        {
+            "X_FORWARDED_FOR": "90.243.238.50, 130.176.222.238, 127.0.0.1",
+        },
+    )
+
+    assert _get_client_ip_address(wsgi_request) == "90.243.238.50"

--- a/tests/events/test_log_authentication.py
+++ b/tests/events/test_log_authentication.py
@@ -123,7 +123,7 @@ class TestLogAuthentication(CommonEvents):
         assert structured_log_entry["EventSeverity"] == expected_event_severity
 
     def test_authentication_does_not_populate_fields_which_are_not_provided(self, capsys):
-        wsgi_request = namedtuple("Request", ["environ", "user", "session"])(
+        wsgi_request = namedtuple("Request", ["META", "user", "session"])(
             {"REMOTE_ADDR": "192.168.1.101", "SERVER_NAME": "WebServer.local"},
             namedtuple("User", ["username"])(None),
             namedtuple("Session", ["session_key"])(None),

--- a/tests/events/test_log_file_activity.py
+++ b/tests/events/test_log_file_activity.py
@@ -143,7 +143,7 @@ class TestLogFileActivity(CommonEvents):
             assert structured_log_entry["TargetFileExtension"] == expected_extension
 
     def test_does_not_populate_fields_which_are_not_provided(self, capsys):
-        wsgi_request = namedtuple("Request", ["environ", "user", "session"])(
+        wsgi_request = namedtuple("Request", ["META", "user", "session"])(
             {"REMOTE_ADDR": "192.168.1.101", "SERVER_NAME": "WebServer.local"},
             namedtuple("User", ["username"])(None),
             namedtuple("Session", ["session_key"])(None),


### PR DESCRIPTION
Addresses [DBTP-2201](https://uktrade.atlassian.net/browse/DBTP-2201)

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base


[DBTP-2201]: https://uktrade.atlassian.net/browse/DBTP-2201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ