### PR TITLE
test: Rename class to avoid Pytest thinking it's a test class (off-ticket)

### DIFF
--- a/tests/test_django_log_formatter.py
+++ b/tests/test_django_log_formatter.py
@@ -21,7 +21,7 @@ TEST_FIRST_NAME = "Test first name"
 TEST_PASSWORD = "mypassword123"
 
 
-class TestHandler(logging.Handler):
+class SpyLogHandler(logging.Handler):
     """A handler class which stores LogRecord entries in a list."""
 
     def __init__(self, records_list):
@@ -397,7 +397,7 @@ class TestASIMFormatter:
 
     def _create_request_log_record(self, logger, overrides={}):
         request = self._create_request(overrides=overrides)
-        logger.addHandler(TestHandler(records_list=[]))
+        logger.addHandler(SpyLogHandler(records_list=[]))
         message_content = "testing 123"
         logger.debug(
             "Test log message: %s",


### PR DESCRIPTION
Fixes warning:

```console
PytestCollectionWarning: cannot collect test class 'TestHandler' because it has a __init__ constructor (from: tests/test_django_log_formatter.py)
```

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base
