### PR TITLE
feat: Populate the TargetUrl field for activity events (DBTP-2207)

### DIFF
--- a/django_log_formatter_asim/events/authentication.py
+++ b/django_log_formatter_asim/events/authentication.py
@@ -79,6 +79,7 @@ def log_authentication(
                         - Django Authentication systems current username
                         - Django Session middlewares Session Key
                         - Client IP address
+                        - URL requested by the client
                         - Server hostname
     :param event: What authentication action was attempted, either "Logon" or "Logoff"
     :param result: What outcome did the action have, either "Success", "Failure", "Partial", "NA"
@@ -127,13 +128,18 @@ def log_authentication(
 
     if "hostname" in server:
         log["DvcHostname"] = server["hostname"]
-    elif "SERVER_NAME" in request.META:
-        log["DvcHostname"] = request.META["SERVER_NAME"]
+    elif "HTTP_HOST" in request.META:
+        log["DvcHostname"] = request.get_host()
 
     if "ip_address" in client:
         log["SrcIpAddr"] = client["ip_address"]
     elif client_ip := _get_client_ip_address(request):
         log["SrcIpAddr"] = client_ip
+
+    if "requested_url" in client:
+        log["TargetUrl"] = client["requested_url"]
+    elif "HTTP_HOST" in request.META:
+        log["TargetUrl"] = request.scheme + "://" + request.get_host() + request.get_full_path()
 
     if "role" in user:
         log["ActorUserType"] = user["role"]

--- a/django_log_formatter_asim/events/common.py
+++ b/django_log_formatter_asim/events/common.py
@@ -25,6 +25,8 @@ class Client(TypedDict):
     """Internet Protocol Address of the client making the Authentication
     event."""
     ip_address: Optional[str]
+    """URL requested by the client."""
+    requested_url: Optional[str]
 
 
 class Server(TypedDict):
@@ -33,7 +35,7 @@ class Server(TypedDict):
     """
     A unique identifier for the server which serviced the Authentication event.
 
-    Defaults to the WSGI SERVER_NAME field if not provided.
+    Defaults to the WSGI HTTP_HOST field if not provided.
     """
     hostname: Optional[str]
     """Internet Protocol Address of the server serving this request."""

--- a/django_log_formatter_asim/events/file_activity.py
+++ b/django_log_formatter_asim/events/file_activity.py
@@ -93,6 +93,7 @@ def log_file_activity(
                     from which the following data will be logged if available
                         - Django Authentication systems current username
                         - Client IP address
+                        - URL requested by the client
                         - Server hostname
     :param event: What File Event action was attempted, one of:
                         - FileAccessed
@@ -168,13 +169,18 @@ def log_file_activity(
 
     if "hostname" in server:
         log["DvcHostname"] = server["hostname"]
-    elif "SERVER_NAME" in request.META:
-        log["DvcHostname"] = request.META["SERVER_NAME"]
+    elif "HTTP_HOST" in request.META:
+        log["DvcHostname"] = request.get_host()
 
     if "ip_address" in client:
         log["SrcIpAddr"] = client["ip_address"]
     elif client_ip := _get_client_ip_address(request):
         log["SrcIpAddr"] = client_ip
+
+    if "requested_url" in client:
+        log["TargetUrl"] = client["requested_url"]
+    elif "HTTP_HOST" in request.META:
+        log["TargetUrl"] = request.scheme + "://" + request.get_host() + request.get_full_path()
 
     if "username" in user:
         log["ActorUsername"] = user["username"]

--- a/tests/events/common_events.py
+++ b/tests/events/common_events.py
@@ -3,19 +3,23 @@ from abc import ABC
 from abc import abstractmethod
 from collections import namedtuple
 
+from django.test import RequestFactory
+
 
 class CommonEvents(ABC):
     def test_does_not_populate_srcip_and_dvchostname_when_META_is_not_provided(self, capsys):
-        wsgi_request = namedtuple("Request", ["META", "user", "session"])(
-            {},
-            namedtuple("User", ["username"])(None),
-            namedtuple("Session", ["session_key"])(None),
-        )
+        request_factory = RequestFactory()
+        wsgi_request = request_factory.get("/")
+        wsgi_request.user = namedtuple("User", ["username"])(None)
+        wsgi_request.session = namedtuple("Session", ["session_key"])(None)
+        wsgi_request.META.pop("REMOTE_ADDR", None)
+        wsgi_request.META.pop("HTTP_HOST", None)
 
         self.generate_event(wsgi_request)
 
         structured_log_entry = self._get_structured_log_entry(capsys)
 
+        assert "TargetUrl" not in structured_log_entry
         assert "DvcHostname" not in structured_log_entry
         assert "SrcIpAddr" not in structured_log_entry
 

--- a/tests/events/conftest.py
+++ b/tests/events/conftest.py
@@ -1,12 +1,17 @@
 from collections import namedtuple
 
 import pytest
+from django.test import RequestFactory
 
 
 @pytest.fixture()
 def wsgi_request():
-    return namedtuple("Request", ["META", "user", "session"])(
-        {"REMOTE_ADDR": "192.168.1.101", "SERVER_NAME": "WebServer.local"},
-        namedtuple("User", ["username"])("Adrian"),
-        namedtuple("Session", ["session_key"])("def456"),
+    factory = RequestFactory()
+    request = factory.get(
+        "/steel", secure=True, **{"REMOTE_ADDR": "192.168.1.101", "HTTP_HOST": "WebServer.local"}
     )
+
+    request.user = namedtuple("User", ["username"])("Adrian")
+    request.session = namedtuple("Session", ["session_key"])("def456")
+
+    return request

--- a/tests/events/test_log_file_activity.py
+++ b/tests/events/test_log_file_activity.py
@@ -22,7 +22,7 @@ class TestLogFileActivity(CommonEvents):
                 "username": "Billy-the-fish",
             },
             server={"hostname": "BigServer", "ip_address": "127.0.0.1"},
-            client={"ip_address": "192.168.1.100"},
+            client={"ip_address": "192.168.1.100", "requested_url": "https://trade.gov.uk/fish"},
             file={
                 "path": "s3-1234.bucket.amazon.com/dir1/file.txt",
                 "name": "file.txt",
@@ -44,6 +44,7 @@ class TestLogFileActivity(CommonEvents):
         assert structured_log_entry["DvcHostname"] == "BigServer"
         assert structured_log_entry["DvcIpAddr"] == "127.0.0.1"
         assert structured_log_entry["EventSeverity"] == "Low"
+        assert structured_log_entry["TargetUrl"] == "https://trade.gov.uk/fish"
         assert (
             structured_log_entry["EventMessage"]
             == "Billy tried real hard to get in, but his fishy features werent recognised"
@@ -84,6 +85,7 @@ class TestLogFileActivity(CommonEvents):
         assert structured_log_entry["EventCreated"] == "2025-07-02T08:15:20+00:00"
         assert structured_log_entry["DvcHostname"] == "WebServer.local"
         assert structured_log_entry["SrcIpAddr"] == "192.168.1.101"
+        assert structured_log_entry["TargetUrl"] == "https://WebServer.local/steel"
         assert structured_log_entry["ActorUsername"] == "Adrian"
 
     @pytest.mark.parametrize(
@@ -142,12 +144,9 @@ class TestLogFileActivity(CommonEvents):
         else:
             assert structured_log_entry["TargetFileExtension"] == expected_extension
 
-    def test_does_not_populate_fields_which_are_not_provided(self, capsys):
-        wsgi_request = namedtuple("Request", ["META", "user", "session"])(
-            {"REMOTE_ADDR": "192.168.1.101", "SERVER_NAME": "WebServer.local"},
-            namedtuple("User", ["username"])(None),
-            namedtuple("Session", ["session_key"])(None),
-        )
+    def test_does_not_populate_fields_which_are_not_provided(self, wsgi_request, capsys):
+        wsgi_request.user = namedtuple("User", ["username"])(None)
+        wsgi_request.session = namedtuple("Session", ["session_key"])(None)
 
         log_file_activity(
             wsgi_request,

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -59,3 +59,5 @@ DATABASES = {
         "NAME": "db.sqlite3",
     }
 }
+
+ALLOWED_HOSTS = ["WebServer.local"]


### PR DESCRIPTION
Can be passed in manually by the caller, or it will be pulled from the request URL instead.

Addresses [DBTP-2207](https://uktrade.atlassian.net/browse/DBTP-2207).

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [x] Includes any applicable changes to the documentation in this code base


[DBTP-2207]: https://uktrade.atlassian.net/browse/DBTP-2207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ