### PR TITLE
fix: Events switch Actor* to Target* (DBTP-2214)

### DIFF
--- a/django_log_formatter_asim/events/authentication.py
+++ b/django_log_formatter_asim/events/authentication.py
@@ -119,7 +119,7 @@ def log_authentication(
     event_created = time_generated or datetime.datetime.now(tz=datetime.timezone.utc)
 
     log = {
-        "EventCreated": event_created.isoformat(),  # TODO: Should this really be EventCreated, or TimeGenerated
+        "EventStartTime": event_created.isoformat(),
         "EventSeverity": severity or _default_severity(result),
         "EventOriginalType": _event_code(event, result),
         "EventType": event,
@@ -141,7 +141,7 @@ def log_authentication(
         log["TargetAppName"] = app_name
 
     if container_id := _get_container_id():
-        log["ContainerId"] = container_id
+        log["TargetContainerId"] = container_id
 
     if "ip_address" in client:
         log["SrcIpAddr"] = client["ip_address"]
@@ -154,17 +154,17 @@ def log_authentication(
         log["TargetUrl"] = request.scheme + "://" + request.get_host() + request.get_full_path()
 
     if "role" in user:
-        log["ActorUserType"] = user["role"]
+        log["TargetUserType"] = user["role"]
 
     if "sessionId" in user:
-        log["ActorSessionId"] = user["sessionId"]
+        log["TargetSessionId"] = user["sessionId"]
     elif request.session.session_key:
-        log["ActorSessionId"] = request.session.session_key
+        log["TargetSessionId"] = request.session.session_key
 
     if "username" in user:
-        log["ActorUsername"] = user["username"]
-    elif request.user.username:
-        log["ActorUsername"] = request.user.username
+        log["TargetUsername"] = user["username"]
+    elif hasattr(request, "user") and request.user.username:
+        log["TargetUsername"] = request.user.username
 
     if result_details:
         log["EventResultDetails"] = result_details

--- a/django_log_formatter_asim/events/file_activity.py
+++ b/django_log_formatter_asim/events/file_activity.py
@@ -143,7 +143,7 @@ def log_file_activity(
         "EventSchemaVersion": "0.2.1",
         "EventType": event,
         "EventResult": result,
-        "EventCreated": event_created.isoformat(),  # TODO: Should this really be EventCreated, or TimeGenerated
+        "EventStartTime": event_created.isoformat(),
         "EventSeverity": severity or _default_severity(result),
         "TargetFilePath": file["path"],
     }
@@ -181,7 +181,7 @@ def log_file_activity(
         log["TargetAppName"] = app_name
 
     if container_id := _get_container_id():
-        log["ContainerId"] = container_id
+        log["TargetContainerId"] = container_id
 
     if "ip_address" in client:
         log["SrcIpAddr"] = client["ip_address"]
@@ -194,9 +194,9 @@ def log_file_activity(
         log["TargetUrl"] = request.scheme + "://" + request.get_host() + request.get_full_path()
 
     if "username" in user:
-        log["ActorUsername"] = user["username"]
-    elif request.user.username:
-        log["ActorUsername"] = request.user.username
+        log["TargetUsername"] = user["username"]
+    elif hasattr(request, "user") and request.user.username:
+        log["TargetUsername"] = request.user.username
 
     if result_details:
         log["EventResultDetails"] = result_details

--- a/tests/events/test_log_authentication.py
+++ b/tests/events/test_log_authentication.py
@@ -21,7 +21,11 @@ class TestLogAuthentication(CommonEvents):
                 "role": "Administrator",
                 "sessionId": "abc123",
             },
-            server={"domain_name": "web.trade.gov.uk", "ip_address": "127.0.0.1","service_name": "berry-auctions-frontend",},
+            server={
+                "domain_name": "web.trade.gov.uk",
+                "ip_address": "127.0.0.1",
+                "service_name": "berry-auctions-frontend",
+            },
             client={"ip_address": "192.168.1.100", "requested_url": "https://trade.gov.uk/fish"},
             severity=log_authentication.Severity.Low,
             time_generated=datetime.datetime(2025, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc),
@@ -36,7 +40,7 @@ class TestLogAuthentication(CommonEvents):
         assert structured_log_entry["EventSchemaVersion"] == "0.1.4"
         assert structured_log_entry["EventType"] == "Logon"
         assert structured_log_entry["EventResult"] == "Failure"
-        assert structured_log_entry["EventCreated"] == "2025-01-02T03:04:05+00:00"
+        assert structured_log_entry["EventStartTime"] == "2025-01-02T03:04:05+00:00"
         assert structured_log_entry["HttpHost"] == "web.trade.gov.uk"
         assert structured_log_entry["DvcIpAddr"] == "127.0.0.1"
         assert structured_log_entry["EventSeverity"] == "Low"
@@ -53,9 +57,9 @@ class TestLogAuthentication(CommonEvents):
 
         # ASIM Authentication Specific Fields
         assert structured_log_entry["LogonMethod"] == "Username & Password"
-        assert structured_log_entry["ActorUsername"] == "Billy-the-fish"
-        assert structured_log_entry["ActorSessionId"] == "abc123"
-        assert structured_log_entry["ActorUserType"] == "Administrator"
+        assert structured_log_entry["TargetUsername"] == "Billy-the-fish"
+        assert structured_log_entry["TargetSessionId"] == "abc123"
+        assert structured_log_entry["TargetUserType"] == "Administrator"
 
     @pytest.mark.parametrize(
         "event, event_result, expected_event_code",
@@ -100,13 +104,13 @@ class TestLogAuthentication(CommonEvents):
 
         structured_log_entry = self._get_structured_log_entry(capsys)
 
-        assert structured_log_entry["EventCreated"] == "2025-07-02T08:15:20+00:00"
+        assert structured_log_entry["EventStartTime"] == "2025-07-02T08:15:20+00:00"
         assert structured_log_entry["HttpHost"] == "WebServer.local"
         assert structured_log_entry["SrcIpAddr"] == "192.168.1.101"
         assert structured_log_entry["TargetAppName"] == "export-analytics-frontend"
         assert structured_log_entry["TargetUrl"] == "https://WebServer.local/steel"
-        assert structured_log_entry["ActorUsername"] == "Adrian"
-        assert structured_log_entry["ActorSessionId"] == "def456"
+        assert structured_log_entry["TargetUsername"] == "Adrian"
+        assert structured_log_entry["TargetSessionId"] == "def456"
 
     @pytest.mark.parametrize(
         "event_result, expected_event_severity",
@@ -146,9 +150,9 @@ class TestLogAuthentication(CommonEvents):
 
         structured_log_entry = self._get_structured_log_entry(capsys)
 
-        assert "ActorUserType" not in structured_log_entry
-        assert "ActorSessionId" not in structured_log_entry
-        assert "ActorUsername" not in structured_log_entry
+        assert "TargetUserType" not in structured_log_entry
+        assert "TargetSessionId" not in structured_log_entry
+        assert "TargetUsername" not in structured_log_entry
         assert "DvcIpAddr" not in structured_log_entry
         assert "TargetAppName" not in structured_log_entry
         assert "EventMessage" not in structured_log_entry
@@ -167,11 +171,11 @@ class TestLogAuthentication(CommonEvents):
 
         structured_log_entry = self._get_structured_log_entry(capsys)
 
-        assert structured_log_entry["ActorUserType"] is None
-        assert structured_log_entry["ActorSessionId"] is None
-        assert structured_log_entry["ActorUsername"] is None
+        assert structured_log_entry["TargetUserType"] is None
+        assert structured_log_entry["TargetSessionId"] is None
         assert structured_log_entry["HttpHost"] is None
         assert structured_log_entry["TargetAppName"] is None
+        assert structured_log_entry["TargetUsername"] is None
         assert structured_log_entry["SrcIpAddr"] is None
 
     def generate_event(self, wsgi_request):

--- a/tests/events/test_log_file_activity.py
+++ b/tests/events/test_log_file_activity.py
@@ -22,7 +22,11 @@ class TestLogFileActivity(CommonEvents):
             user={
                 "username": "Billy-the-fish",
             },
-            server={"domain_name": "web.trade.gov.uk", "ip_address": "127.0.0.1","service_name": "berry-auctions-frontend",},
+            server={
+                "domain_name": "web.trade.gov.uk",
+                "ip_address": "127.0.0.1",
+                "service_name": "berry-auctions-frontend",
+            },
             client={"ip_address": "192.168.1.100", "requested_url": "https://trade.gov.uk/fish"},
             file={
                 "path": "s3-1234.bucket.amazon.com/dir1/file.txt",
@@ -41,7 +45,7 @@ class TestLogFileActivity(CommonEvents):
         assert structured_log_entry["EventSchemaVersion"] == "0.2.1"
         assert structured_log_entry["EventType"] == "FileAccessed"
         assert structured_log_entry["EventResult"] == "Success"
-        assert structured_log_entry["EventCreated"] == "2025-01-02T03:04:05+00:00"
+        assert structured_log_entry["EventStartTime"] == "2025-01-02T03:04:05+00:00"
         assert structured_log_entry["HttpHost"] == "web.trade.gov.uk"
         assert structured_log_entry["DvcIpAddr"] == "127.0.0.1"
         assert structured_log_entry["EventSeverity"] == "Low"
@@ -55,7 +59,7 @@ class TestLogFileActivity(CommonEvents):
         assert structured_log_entry["EventResultDetails"] == "Really top notch GetObject"
 
         # ASIM FileEvent Specific Fields
-        assert structured_log_entry["ActorUsername"] == "Billy-the-fish"
+        assert structured_log_entry["TargetUsername"] == "Billy-the-fish"
         assert structured_log_entry["TargetFilePath"] == "s3-1234.bucket.amazon.com/dir1/file.txt"
         assert structured_log_entry["TargetFileName"] == "file.txt"
         assert structured_log_entry["TargetFileExtension"] == "txt"
@@ -88,12 +92,12 @@ class TestLogFileActivity(CommonEvents):
 
         structured_log_entry = self._get_structured_log_entry(capsys)
 
-        assert structured_log_entry["EventCreated"] == "2025-07-02T08:15:20+00:00"
+        assert structured_log_entry["EventStartTime"] == "2025-07-02T08:15:20+00:00"
         assert structured_log_entry["HttpHost"] == "WebServer.local"
         assert structured_log_entry["SrcIpAddr"] == "192.168.1.101"
         assert structured_log_entry["TargetAppName"] == "export-analytics-frontend"
         assert structured_log_entry["TargetUrl"] == "https://WebServer.local/steel"
-        assert structured_log_entry["ActorUsername"] == "Adrian"
+        assert structured_log_entry["TargetUsername"] == "Adrian"
 
     @pytest.mark.parametrize(
         "event_result, expected_event_severity",
@@ -166,7 +170,7 @@ class TestLogFileActivity(CommonEvents):
 
         structured_log_entry = self._get_structured_log_entry(capsys)
 
-        assert "ActorUsername" not in structured_log_entry
+        assert "TargetUsername" not in structured_log_entry
         assert "DvcIpAddr" not in structured_log_entry
         assert "TargetAppName" not in structured_log_entry
         assert "EventMessage" not in structured_log_entry
@@ -191,7 +195,7 @@ class TestLogFileActivity(CommonEvents):
 
         structured_log_entry = self._get_structured_log_entry(capsys)
 
-        assert structured_log_entry["ActorUsername"] is None
+        assert structured_log_entry["TargetUsername"] is None
         assert structured_log_entry["HttpHost"] is None
         assert structured_log_entry["SrcIpAddr"] is None
         assert structured_log_entry["TargetAppName"] is None


### PR DESCRIPTION
The Authentication ASIM guidance recommends using Target for the primary authentication details.

https://uktrade.atlassian.net/browse/DBTP-2214

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base
