### PR TITLE
fix: Rename ContainerTaskId field to ContainerId field (off-ticket)

### DIFF
--- a/django_log_formatter_asim/events/authentication.py
+++ b/django_log_formatter_asim/events/authentication.py
@@ -141,7 +141,7 @@ def log_authentication(
         log["TargetAppName"] = app_name
 
     if container_id := _get_container_id():
-        log["ContainerTaskId"] = container_id
+        log["ContainerId"] = container_id
 
     if "ip_address" in client:
         log["SrcIpAddr"] = client["ip_address"]

--- a/django_log_formatter_asim/events/file_activity.py
+++ b/django_log_formatter_asim/events/file_activity.py
@@ -181,7 +181,7 @@ def log_file_activity(
         log["TargetAppName"] = app_name
 
     if container_id := _get_container_id():
-        log["ContainerTaskId"] = container_id
+        log["ContainerId"] = container_id
 
     if "ip_address" in client:
         log["SrcIpAddr"] = client["ip_address"]

--- a/tests/events/common_events.py
+++ b/tests/events/common_events.py
@@ -25,24 +25,22 @@ class CommonEvents(ABC):
         assert "HttpHost" not in structured_log_entry
         assert "SrcIpAddr" not in structured_log_entry
 
-    def test_populates_containertaskid_when_environment_variable_available(
-        self, wsgi_request, capsys
-    ):
+    def test_populates_containerid_when_environment_variable_available(self, wsgi_request, capsys):
         os.environ["ECS_CONTAINER_METADATA_URI"] = "http://blah/testid"
         self.generate_event(wsgi_request)
         del os.environ["ECS_CONTAINER_METADATA_URI"]
         structured_log_entry = self._get_structured_log_entry(capsys)
 
-        assert structured_log_entry["ContainerTaskId"] == "testid"
+        assert structured_log_entry["ContainerId"] == "testid"
 
-    def test_does_not_populate_containertaskid_when_environment_variable_not_set(
+    def test_does_not_populate_containerid_when_environment_variable_not_set(
         self, wsgi_request, capsys
     ):
         self.generate_event(wsgi_request)
 
         structured_log_entry = self._get_structured_log_entry(capsys)
 
-        assert "ContainerTaskId" not in structured_log_entry
+        assert "ContainerId" not in structured_log_entry
 
     @abstractmethod
     def generate_event(self, wsgi_request):


### PR DESCRIPTION
The field is populated with the Docker Container Id, so renaming makes sense.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base
