### PR TITLE
docs: Be explicit about which fields are mandatory for logging (off-ticket)

### DIFF
--- a/django_log_formatter_asim/events/authentication.py
+++ b/django_log_formatter_asim/events/authentication.py
@@ -31,7 +31,7 @@ class AuthenticationLoginMethod(str, Enum):
     ExternalIDP = "External IdP"
 
 
-class AuthenticationUser(TypedDict):
+class AuthenticationUser(TypedDict, total=False):
     """Dictionary to represent properties of the users session."""
 
     """What type of role best describes this Authentication event."""

--- a/django_log_formatter_asim/events/common.py
+++ b/django_log_formatter_asim/events/common.py
@@ -19,7 +19,7 @@ class Severity(str, Enum):
     High = "High"
 
 
-class Client(TypedDict):
+class Client(TypedDict, total=False):
     """Dictionary to represent properties of the HTTP Client."""
 
     """Internet Protocol Address of the client making the Authentication
@@ -29,7 +29,7 @@ class Client(TypedDict):
     requested_url: Optional[str]
 
 
-class Server(TypedDict):
+class Server(TypedDict, total=False):
     """Dictionary to represent properties of the HTTP Server."""
 
     """

--- a/django_log_formatter_asim/events/file_activity.py
+++ b/django_log_formatter_asim/events/file_activity.py
@@ -31,14 +31,19 @@ class FileActivityEvent(str, Enum):
     FolderModified = "FolderModified"
 
 
-class FileActivityFile(TypedDict):
-    """Dictionary to represent properties of the target file."""
+class FileActivityFileBase(TypedDict):
+    """Mandatory field definitions of FileActivityFile."""
 
     """
-    The full, normalized path of the target file, including the folder or location,
-    the file name, and the extension.
+    The full, normalized path of the target file, including the folder or
+    location, the file name, and the extension.
     """
     path: str
+
+
+class FileActivityFile(FileActivityFileBase, total=False):
+    """Dictionary to represent properties of the target file."""
+
     """
     The name of the target file, without a path or a location, but with an
     extension if available. This field should be similar to the final element in
@@ -65,7 +70,7 @@ class FileActivityFile(TypedDict):
     size: Optional[int]
 
 
-class FileActivityUser(TypedDict):
+class FileActivityUser(TypedDict, total=False):
     """
     A unique identifier for the user.
 


### PR DESCRIPTION
TypedDicts have a property "total" which if set to False means that the fields don't need to be specified.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base
