### PR TITLE
docs: Add warning about DLFA_INCLUDE_RAW_LOG (DBTP-2335)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,19 @@ We then set `propagate` to `False` on the `django` logger, to avoid duplicating 
 
 `DLFA_TRACE_HEADERS` - used for defining custom zipkin headers, the defaults is `("X-Amzn-Trace-Id")`, but for applications hosted in GOV.UK PaaS you should use `("X-B3-TraceId", "X-B3-SpanId")`. If you are running your application in both places side by side during migration, the following should work in your Django settings:
 
-`DLFA_INCLUDE_RAW_LOG` - By default the original unformatted log is not included in the ASIM formatted log. You can enable that by setting this to `True` and it will be included in `AddidtionalFields.RawLog`.
-
 ```python
 from dbt_copilot_python.utility import is_copilot
 
 if is_copilot():
    DLFA_TRACE_HEADERS = ("X-B3-TraceId", "X-B3-SpanId")
 ```
+
+`DLFA_INCLUDE_RAW_LOG` - By default the original unformatted log is not included in the ASIM formatted log. You can enable that by setting this to `True` and it will be included in `AddidtionalFields.RawLog`.
+
+> [!WARNING]
+> Setting `DLFA_INCLUDE_RAW_LOG` to `True` will cause additional private fields to be output to your logs.
+> This could include secrets, such as AWS Access Keys, private HTTP Request data, or personally identifiable information.
+> This setting is not recommended for a production environment.
 
 ### Serialisation behaviour
 


### PR DESCRIPTION
When investigating sensitive data being output to logs, this setting is a source of unintentional data leaking.

Addresses [DBTP-2335](https://uktrade.atlassian.net/browse/DBTP-2335).

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base


[DBTP-2335]: https://uktrade.atlassian.net/browse/DBTP-2335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ