### PR TITLE
feat: Enable Datadog Error Tracking for Logs (DBTP-2123)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ if is_copilot():
 > This could include secrets, such as AWS Access Keys, private HTTP Request data, or personally identifiable information.
 > This setting is not recommended for a production environment.
 
+`DLFA_DATADOG_ERROR_TRACKING_FOR_LOGS` - By default the [required attributes for Datadog Error Tracking for Logs](https://docs.datadoghq.com/logs/error_tracking/backend/?tab=serilog#attributes-for-error-tracking) are not included. You can include these by setting this to `True`. This will surface error logs as errors in Datadog, similarly to Sentry.
+
 ### Serialisation behaviour
 
 The package provides one `logging.Formatter` class, `ASIMFormatter` which routes log messages to a serialiser

--- a/poetry.lock
+++ b/poetry.lock
@@ -201,14 +201,14 @@ files = [
 
 [[package]]
 name = "django"
-version = "4.2.26"
+version = "4.2.27"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "django-4.2.26-py3-none-any.whl", hash = "sha256:c96e64fc3c359d051a6306871bd26243db1bd02317472a62ffdbe6c3cae14280"},
-    {file = "django-4.2.26.tar.gz", hash = "sha256:9398e487bcb55e3f142cb56d19fbd9a83e15bb03a97edc31f408361ee76d9d7a"},
+    {file = "django-4.2.27-py3-none-any.whl", hash = "sha256:f393a394053713e7d213984555c5b7d3caeee78b2ccb729888a0774dff6c11a8"},
+    {file = "django-4.2.27.tar.gz", hash = "sha256:b865fbe0f4a3d1ee36594c5efa42b20db3c8bbb10dff0736face1c6e4bda5b92"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
To manually Enable Error Tracking for Logs, the `error.kind` and one of `error.message` or `error.stacktrace` attributes must be present in the log.

From DLFA, we're only concerned about adding errors for logs which aren't triggered by an exception, either handled or unhandled, as this is handled by the `ddtrace-py` library.

This functionality is being added to mirror the automatic logger integration provided by the Sentry SDK within Datadog.

Addresses https://uktrade.atlassian.net/browse/DBTP-2123.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [x] Includes any applicable changes to the documentation in this code base
