### PR TITLE
fix: Allow a greater set of versions of ddtrace to be used (off-ticket)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -25,6 +25,7 @@ description = "Python module to generate and modify bytecode"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version < \"3.14.0\""
 files = [
     {file = "bytecode-0.16.1-py3-none-any.whl", hash = "sha256:1d4b61ed6bade4bff44127c8283bef8131a664ce4dbe09d64a88caf329939f35"},
     {file = "bytecode-0.16.1.tar.gz", hash = "sha256:8fbbb637c880f339e564858bc6c7984ede67ae97bc71343379a535a9a4baf398"},
@@ -32,6 +33,19 @@ files = [
 
 [package.dependencies]
 typing_extensions = {version = "*", markers = "python_version < \"3.10\""}
+
+[[package]]
+name = "bytecode"
+version = "0.17.0"
+description = "Python module to generate and modify bytecode"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version >= \"3.14.0\""
+files = [
+    {file = "bytecode-0.17.0-py3-none-any.whl", hash = "sha256:64fb10cde1db7ef5cc39bd414ecebd54ba3b40e1c4cf8121ca5e72f170916ff8"},
+    {file = "bytecode-0.17.0.tar.gz", hash = "sha256:0c37efa5bd158b1b873f530cceea2c645611d55bd2dc2a4758b09f185749b6fd"},
+]
 
 [[package]]
 name = "cachetools"
@@ -83,91 +97,156 @@ files = [
 
 [[package]]
 name = "ddtrace"
-version = "3.2.1"
+version = "4.0.3"
 description = "Datadog APM client library"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
+markers = "python_version >= \"3.14.0\""
 files = [
-    {file = "ddtrace-3.2.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:912e5a824312861e877f6f976ab95c4eb01ab920cfaccc69c87dc5015309f6f4"},
-    {file = "ddtrace-3.2.1-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:d54a2383e7db6f28f395b771270ecacdeba32315ddb39f3c256b554271a0a513"},
-    {file = "ddtrace-3.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d5b3eea2eb6e5c5e2956ea8706906fad72cd3bd270297396a91db940511b075"},
-    {file = "ddtrace-3.2.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:429e95ec0cae4a10b506c9a2d010eaa7f40a73086c58eca40bb51c640d25c9bb"},
-    {file = "ddtrace-3.2.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56dec8fb650ad7b237706b1f16c76628eee7315b7820e5515c2844c3e2593005"},
-    {file = "ddtrace-3.2.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:bdae569a745a38eb57003f8293056b2e9e736ca11753149b6b8b67c37ae74949"},
-    {file = "ddtrace-3.2.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:d05d3745be16a92fba4fca9415376613c7e04f7dc47aaf6aaa4f9502e00e65cb"},
-    {file = "ddtrace-3.2.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b9b804dc73621e3cb867f6a6b03847d25c62798cdb1cca874fbfa4ce6e536105"},
-    {file = "ddtrace-3.2.1-cp310-cp310-win32.whl", hash = "sha256:994b02a566cbc33ed686ee03d23fea11741775096babe2b3a9b4fd8781cf65f6"},
-    {file = "ddtrace-3.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:d5c6c479841b0144017f3786197f0aa9bfb65bdc4d103a2e343aae8c0d065b5a"},
-    {file = "ddtrace-3.2.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:4c463262a5c2381dae3776f51a335310e2474deaf863997f4f0393ec2fcb6442"},
-    {file = "ddtrace-3.2.1-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:9669924ef069a9f85c424837d73fb13377fef67d2926e7f68f06fef4467f7352"},
-    {file = "ddtrace-3.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8d0d3a4dd0dcff2af95666235838af29eae8fd489df8938527ad7d5f40db93c"},
-    {file = "ddtrace-3.2.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:793da357c0121ee8b9203d776e577d55ff9dd5c1ec827fd669bcc35058d7278b"},
-    {file = "ddtrace-3.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7cd268fc09e7183e3457963a1534331fd838b890da827db7e5ef992e6bd5e96"},
-    {file = "ddtrace-3.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:62c3aef2b677299947fefb899b914158a4f3af63cefb6f7c4d9d2cf06865ce44"},
-    {file = "ddtrace-3.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:90c641c97ad10475723fd12c5708247c2a796a4ccd5a27195502993b3baeb513"},
-    {file = "ddtrace-3.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b3852a62155fe0cc500c7a633cb76d3c14bf53e96d9c3936a0d24a22cee22d03"},
-    {file = "ddtrace-3.2.1-cp311-cp311-win32.whl", hash = "sha256:78b6683c3d8cbb3d1048f6d7742b12749790abfd6a24ed07d35c61c171167617"},
-    {file = "ddtrace-3.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:e28337b86e0dcb4c2573248bcbc6706406a2fa496f772495609594f5a50e7003"},
-    {file = "ddtrace-3.2.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:316f31a4354ab92208b46ed46df9009726831982b072ed79d7f1f411ac6a10af"},
-    {file = "ddtrace-3.2.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:4ae996fbe7c1e3a345b9dce96a030801597fec14b8284574252b2c4dc45a802d"},
-    {file = "ddtrace-3.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa39e9587b81c5d342166b9b1b9ea6751954f89324111d52984d9e1cffca4e57"},
-    {file = "ddtrace-3.2.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2beda81f25dad61cb657188f92199c603ee3aef5d9a53a2bf24e4cf2620e699"},
-    {file = "ddtrace-3.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8fd86d1d47a5f82bb2bda73d339ec434427c5fcb2d259f825d18b097fc2fa3e1"},
-    {file = "ddtrace-3.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2cd1febea180a494e67ae0388055f3aaa8f63cb090dcf1ce4c3054c2162e05d1"},
-    {file = "ddtrace-3.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f8964c3cf0c3ef8dd066323b4ed0fbe561ca56f4a0bbe591b5e8e65411cc955f"},
-    {file = "ddtrace-3.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6a8ca3d670f4c3a873f24fcfb25f9324193b361edb57bbeadc3b90257a3494c2"},
-    {file = "ddtrace-3.2.1-cp312-cp312-win32.whl", hash = "sha256:c9ffa96777be82566c990a30216aac00ff84b256d7d0a428ed4a63e4666b6c3e"},
-    {file = "ddtrace-3.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:c2d6c34ed0f7986e9afbd8c991bb4e7049cc5631837708b400dd1c6b108058f9"},
-    {file = "ddtrace-3.2.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8db2b0aa025ac50b1a4516bdd722ede4a0d70d7c31df7b4ca0842aadfacc8276"},
-    {file = "ddtrace-3.2.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:65715768745d609e88d77e7a843477dd8e08da382f6058672210c412924d83af"},
-    {file = "ddtrace-3.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:003b5de6e28224129e8ba103bd8de26e7571b8c5a9141fdc70f91ad4b15fb4a0"},
-    {file = "ddtrace-3.2.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:28a05aaa595e763ce7c46a4d186da2314c795ed7311efe506a58760f77ce3d13"},
-    {file = "ddtrace-3.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:530cdd0570c5a5c9df420924f992800e90fcb5f556c1a2cd6d83ee4c3356072d"},
-    {file = "ddtrace-3.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c38fa59a6e999c7a95c508f3dd020a74173c77ca19517a2257394d7b4329331f"},
-    {file = "ddtrace-3.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:92de3eed2d2a3ed58a75ad8f44c2897614b9c905dba26b0d29989f849069896e"},
-    {file = "ddtrace-3.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:157617ee0a8a7a7dd55c9e0e293c8a9f01bc0cbeddc8f36e61d2ce0e95a04be3"},
-    {file = "ddtrace-3.2.1-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:0f52367b665ae75d47c444f709b650c2457cd92c76171c03de76247654ac0d76"},
-    {file = "ddtrace-3.2.1-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:d51d98b5714d9a02e6a919de211851170a829b88c407d1fb594dd0f72a241af3"},
-    {file = "ddtrace-3.2.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d47c042e5857c34d775858e0b1fde95bd4fe64b3dac27c7cb756fd593812077"},
-    {file = "ddtrace-3.2.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2f73d78d58c2964c1073c4dc410edaa2de2d4a343878c19e06a4f14df3f1808d"},
-    {file = "ddtrace-3.2.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:752bd25994a191cc998029294f38b2355c76ad7c50a82705994695ac22a95675"},
-    {file = "ddtrace-3.2.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:dadcdc75300961d70367ac21e3b7f3b43e1df27894c7be84e14e23be00d7edc4"},
-    {file = "ddtrace-3.2.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:125f286749493a4cd6785425adc944b0df82c96b8c540c8dba2769b5ef42dc7c"},
-    {file = "ddtrace-3.2.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:0c995c4e71db065a34d8a8657392180dded906ada73d33d0d5c8796070da1cbc"},
-    {file = "ddtrace-3.2.1-cp38-cp38-win32.whl", hash = "sha256:0d02456cf5839f33b78d66461cf0a6e8667669f9a440633687e4753f10505652"},
-    {file = "ddtrace-3.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:cd363d87fdbcd6ec4a4096e287d21a133758eea36abe7928558b4ab709cb33cc"},
-    {file = "ddtrace-3.2.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:8c9e672d05b0a0f6519d42b50ff5a09f40d61dc9c93780896a3557dcca16e658"},
-    {file = "ddtrace-3.2.1-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:03b2fb551b55bb82f150b1ebe85956a54fe79e137ba34a5e9a6e15ae6ceb53a0"},
-    {file = "ddtrace-3.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2023770220a263f40684570293045f13ca6f664140ce88f53d4e3936e4fa661b"},
-    {file = "ddtrace-3.2.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4762448408b3365108c5636a947c018c494af7e69526a65046290df284b4ee96"},
-    {file = "ddtrace-3.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:347f21d1fef2884bbcfdf183406b25e5a8b26973ae15bf5b37d9461d6a229ea3"},
-    {file = "ddtrace-3.2.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:074abe5a3e887175e7fd3132531353279aeaa89cf113b7e9a75549bf7cc94e7a"},
-    {file = "ddtrace-3.2.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:2b518df5d907a8427cd60007b5169cd649fc55c1f972dab3ebf6abfff757d3ed"},
-    {file = "ddtrace-3.2.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:3a7a225953b991712aa57d8680063db5d078d9d11a1a3fc5c8bf2da0880f7717"},
-    {file = "ddtrace-3.2.1-cp39-cp39-win32.whl", hash = "sha256:76b44972e3d1201c88f56a56ec2ea46c4fb98735a92e2dab1957b694498a91a1"},
-    {file = "ddtrace-3.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:0877e52e46039f3a41a7e423f8b70d22635c66b397f33207a89897a598ed3228"},
-    {file = "ddtrace-3.2.1.tar.gz", hash = "sha256:d7fd33aa80131bc7cc619cd5bc63395c8ae2566aa49e5877d8d4295044b07ddd"},
+    {file = "ddtrace-4.0.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:7b22bf851084efa7614e1c00364fed6b49cfe5867355170828885230ca85a129"},
+    {file = "ddtrace-4.0.3-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:08aa247e3d7227237313df0cd9a8d9fd10fb40e130339dc43c740435c09ffc58"},
+    {file = "ddtrace-4.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3357e506513b236696011a3f4342f097f05b2bf63349eb5e93b6bed75d96efa7"},
+    {file = "ddtrace-4.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a3891aabd5e4943e398b5a05a73e6828bd958162985e87d152d93e4fcb2e2b7f"},
+    {file = "ddtrace-4.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5a3d2c16b647fdd602e695d5fc47e71289824dd55f314cc4b0c6699353bacc9b"},
+    {file = "ddtrace-4.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9a18d24c73881d95127a5f57e6a475cf0dbef6f55b4e4ae11e7afc6baaef9adb"},
+    {file = "ddtrace-4.0.3-cp310-cp310-win32.whl", hash = "sha256:2b06756f4a1d2ba0dc3d82345cafab6f3f4f8ae9ed7d600f640fca6f48c72d5a"},
+    {file = "ddtrace-4.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:4d67f10f531b68545cd88c1b7705b1d0242aa25eb3c693a7418ecd42881c2b03"},
+    {file = "ddtrace-4.0.3-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:813956bf27a8c9923d34a56c79f5cbf0685bddcfb2f24517fbaedca756cf3aa6"},
+    {file = "ddtrace-4.0.3-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:5e32bcd070a8a68c62db2fd1957152537732bd9f64adf6c90657b5ae3ccaa8f7"},
+    {file = "ddtrace-4.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e3b2a7d791070f38e2c080230f9e112c0e451d6f00f926788d3116de952380b7"},
+    {file = "ddtrace-4.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a383eed1e8f6f967771d8d599a5edd093a85d5bef9647feb677dac125dbb74ac"},
+    {file = "ddtrace-4.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2325cafa1d8fe499f77785700dbe12498daf13714c230f8d16398ae6b8407a21"},
+    {file = "ddtrace-4.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:82de8b1ce4b234538417918485b0e40545286f56b6834f6ebe3bb3e8aa1697f5"},
+    {file = "ddtrace-4.0.3-cp311-cp311-win32.whl", hash = "sha256:505ddccd7d02c58aabe1214d386a628ba984d7268d49c5baf2b0c9c95b58f4c5"},
+    {file = "ddtrace-4.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:951922ff23b924a1386ab92197ce796f641d96c0453c7477318b6a618fb0ef21"},
+    {file = "ddtrace-4.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:63c1f1c5acc6e67c9cf069f671879da6808671bc49b0723af16fd565cda4d522"},
+    {file = "ddtrace-4.0.3-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:87a5140e0eefd462ccc5de40a17a0ce2747b7f8cd6e5b35d69e942dac75acf8f"},
+    {file = "ddtrace-4.0.3-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:92e48a89f6dd7288bbc2195a2035c73514bbcb66b08feb28756546ae17ec4521"},
+    {file = "ddtrace-4.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0bdcc96fc960783f3928392f3660d3908e6df0eca8d95b0f7dca6787cb309815"},
+    {file = "ddtrace-4.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc76dfae116ea405c542e428a3865c0d60bebbfce8d9a4284b1f45d3d6edeacc"},
+    {file = "ddtrace-4.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:352ca045c93e0657b0550d9b18e01c8ad9506090842787331f15cbf7521b24fe"},
+    {file = "ddtrace-4.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0d2d6db191bde85428e89a5f4bbed58374a09ab27871e9d95106079aa412ac9d"},
+    {file = "ddtrace-4.0.3-cp312-cp312-win32.whl", hash = "sha256:c4f8e3548fb0ff0ab9f37f1d64a21d18e13590f5ddfa288a9d3152ebc76b9f36"},
+    {file = "ddtrace-4.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:71241fba54e2631e718085366c855a53ab38acf807e3b505706d222c6a053027"},
+    {file = "ddtrace-4.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:f08d52a18aacaa0819f8ea536d6ed9a834f1bb4470d45f2ef8831abae7bd8630"},
+    {file = "ddtrace-4.0.3-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:87720f9d2a806841fce3278bfdac36a418688e9924e438207e059ff913896f89"},
+    {file = "ddtrace-4.0.3-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:6851a5ebd5598a59dd1116fff362f51284169d6ea5bccaf3812545a2db6b6471"},
+    {file = "ddtrace-4.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e73de6a6e8e6da79a51d66b826da6dee84a73c1712acc52f25446cdc21439c86"},
+    {file = "ddtrace-4.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:05f451da5ea038bb3288825739d4f3d7b79034593b6e4bcc5871036300d1c030"},
+    {file = "ddtrace-4.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1e9922dc125c7985201a45f2d14c9b8189bdd05da3a586ef19dee51bb602025d"},
+    {file = "ddtrace-4.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8a0c30681413c272e6961742dceba4d3dec64ea6ebd0a1fcd12ec11eb1bacfbf"},
+    {file = "ddtrace-4.0.3-cp313-cp313-win32.whl", hash = "sha256:34e20d46671277e3c0b4e484cba57074e7b5751e721ce977948e7b59308fee36"},
+    {file = "ddtrace-4.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:4fb9c73f87f0985afd0933db9e457a278ba3bd0f2eb0571758b2b1923b34ad5b"},
+    {file = "ddtrace-4.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:59428ed37b8adec2b58e4a2555e51432899b58372559cbd8be5e3e227f98fbfb"},
+    {file = "ddtrace-4.0.3-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:ecf2ccb2957caa8b82945f1432ffcde041673df76635620c1fa162377a34db84"},
+    {file = "ddtrace-4.0.3-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:b54daf04ba98cf26c74650aa459e22165d5c61e13bdb69d2a55db9bb81d2fb88"},
+    {file = "ddtrace-4.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9d80039a225d250b74c39b5fc8c257eba0691e9c2e7c5e00be57f22180489ee9"},
+    {file = "ddtrace-4.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a4bc7ca165ab463f4da22e8b21febabc604f7be8f1cbb392a993020ce459a38f"},
+    {file = "ddtrace-4.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:cfce722912ef3d2c6a023fc69ab0ff67162bc1d968feef839351726979d4ef8b"},
+    {file = "ddtrace-4.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:880088ddfd99a25c593db3e04c56e335f2a011b0ed106c8709787c0790371df5"},
+    {file = "ddtrace-4.0.3-cp314-cp314-win32.whl", hash = "sha256:dd1a4f349fe4d7be463a1b7cd8490dcf7b782f1474791159ac6515c2c62012a3"},
+    {file = "ddtrace-4.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:8c27d5f3de3aed268ac79d532e7852083c34775ada38be92e37e8bf8eb42e184"},
+    {file = "ddtrace-4.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:1ece29a9f5bca662319ac5b1848a29e509106ca1624dd5b32782363c93a785dc"},
+    {file = "ddtrace-4.0.3-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:8fb3caec6bdc3b4aad682d2ad833122dfc9019fbaed418747a4772a60c2134f7"},
+    {file = "ddtrace-4.0.3-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:1b6ad098036a8ba8aae373babfb2f7dd1c044576da15ffe26f8af2f223391aea"},
+    {file = "ddtrace-4.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:819f5e595d2c1f1c119dcef452713a639e6722f2dfa3afa3b4d9a242f555665b"},
+    {file = "ddtrace-4.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1fa8102d85c5621230c11498ed304cae061ca478b0942fb0015391d8089ec748"},
+    {file = "ddtrace-4.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:80f34e2e76bff91b6563d9166796cf3af6874c090b00f6f04e021c8ec1c6e7ab"},
+    {file = "ddtrace-4.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:effed8a9f1032ee3b6058b5c3d37136a8cb2c5b89da0e906cd4fea90088e89d8"},
+    {file = "ddtrace-4.0.3-cp39-cp39-win32.whl", hash = "sha256:6ed5efb8f6ebd220dfb7673e05619760a9f707a429b16b26fddf7d660786ef3e"},
+    {file = "ddtrace-4.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:3b305ee266a63e419dd76c4cd5a87f8ddf11f6075c852fd2218345043f519a3a"},
+    {file = "ddtrace-4.0.3.tar.gz", hash = "sha256:b80862b2b3b9306369dfc923e7efa34b78e83e71ea7fe9182e3c3952ebae9058"},
+]
+
+[package.dependencies]
+bytecode = {version = ">=0.17.0,<1", markers = "python_version >= \"3.14.0\""}
+envier = ">=0.6.1,<0.7.0"
+opentelemetry-api = ">=1,<2"
+wrapt = ">=1,<3"
+
+[package.extras]
+opentelemetry = ["opentelemetry-exporter-otlp (>=1,<2)"]
+opentracing = ["opentracing (>=2,<3)"]
+
+[[package]]
+name = "ddtrace"
+version = "4.1.3"
+description = "Datadog APM client library"
+optional = false
+python-versions = "<3.15,>=3.9"
+groups = ["main"]
+markers = "python_version < \"3.14.0\""
+files = [
+    {file = "ddtrace-4.1.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:8acb0d52d09af30201c9b3a53fe8dea7aad14e3669ed0af7c8bf4fcf145bc08e"},
+    {file = "ddtrace-4.1.3-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:158d1a31afd3c1af13232ce51a10b1f458ee760619e389f60547312ada4ca9f9"},
+    {file = "ddtrace-4.1.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:71292fcecd60e704b7e07bd81009ed96c50a855ccd673ed5631c2cfab4ceb481"},
+    {file = "ddtrace-4.1.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3ec2fbb408e253f8ceafcb3d6719d91dff7d1de3fb5bf901fbdfaa723f0a874a"},
+    {file = "ddtrace-4.1.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5538b11d5798a370eeda0fe96db8d395e3c2619de9f393e7413cb3835125fe6c"},
+    {file = "ddtrace-4.1.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:6ec0a13352ec6a3bb6e5f9d0cd56488da72f7c41b8669b66d6caa042847b624d"},
+    {file = "ddtrace-4.1.3-cp310-cp310-win32.whl", hash = "sha256:0cb67a9adfc597d0cbe7343c955a3f825ec2397bb665d24a3f0cc259ac67baff"},
+    {file = "ddtrace-4.1.3-cp310-cp310-win_amd64.whl", hash = "sha256:8dbb3f14712da9da9ebd43de7ed52c26f31e573708edb78ee412bf5859a8c4f8"},
+    {file = "ddtrace-4.1.3-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:026352e94216e29cbdda70a1abdea7cf9029751c50191d16676f0c8460671167"},
+    {file = "ddtrace-4.1.3-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:62e4ed2ce9bba6695991c21312c35edef31d60f5075532f6392e94526d5b1dad"},
+    {file = "ddtrace-4.1.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9a1346057b6cbfb5f8df77a99e2e3f1afbaea6291c6e607fa78612dd8cd1de17"},
+    {file = "ddtrace-4.1.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:eb1ac1b00be7610159e46164dae8bf5993676a316fce60bb4c5b0405725b825a"},
+    {file = "ddtrace-4.1.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bc82a8b66fff45a2e8ee272bbeb6c0bca95cd2d822fc02189ccb0358a7cb65cf"},
+    {file = "ddtrace-4.1.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:2b06878fb751e69ebbe1de929118a0a6ffa931ee5eb87b17932cf2c1848e9585"},
+    {file = "ddtrace-4.1.3-cp311-cp311-win32.whl", hash = "sha256:5fc823c028041f0e10aa5cbc0f45436806e304ad7827cd7a8314c23e4165519f"},
+    {file = "ddtrace-4.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:418bf215e8c25002490f2c071f9a551760f2a07d5ba018dcc55710db32dbb37a"},
+    {file = "ddtrace-4.1.3-cp311-cp311-win_arm64.whl", hash = "sha256:75fb0c63a19f261595f35d30877bc84cea528cc7cc226d5035b5aab419cf1f01"},
+    {file = "ddtrace-4.1.3-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:76f38d02048682b97881a258a12ad13bd390cc9666007c0eb8154521c19ff125"},
+    {file = "ddtrace-4.1.3-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:3631ef1d30df47a25faa1ddea28c45c6b6db6e60c24c239d740418259d2bbf4c"},
+    {file = "ddtrace-4.1.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2d35825cf9fc5a0e95801e2bb21e7721deac360cb9da7d14f1912da5c71250b5"},
+    {file = "ddtrace-4.1.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a649f90f34c1eddaa02adabfb819fa505f362fd439918a0ef2762430c1d016dc"},
+    {file = "ddtrace-4.1.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5cf451bae83fcb12c965d6fb73b42e06f05180763257aca44e333bdd4775ab8"},
+    {file = "ddtrace-4.1.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:644a09f7f281f38a4ffa0d5f5667286a8593cdb0fe57d012f12ed265191abc43"},
+    {file = "ddtrace-4.1.3-cp312-cp312-win32.whl", hash = "sha256:a1205d93a3e43836342a3968c9682afe6b2246a9e203ed01914f082bf4a87853"},
+    {file = "ddtrace-4.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:cad5460e3dec6d226514fb9bf9871375554f5f0f297f0ca0e63541453da5c61a"},
+    {file = "ddtrace-4.1.3-cp312-cp312-win_arm64.whl", hash = "sha256:d4a54395f9daaa54548098c8bac22e6b4720ee8e37a000e0f979f07bcb71ce9a"},
+    {file = "ddtrace-4.1.3-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:46edcd4975bcc1af7fb88e3311c647783070c76b6ce822afccf31601106074a0"},
+    {file = "ddtrace-4.1.3-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:9592d779dfb9c801feabfb1c35c406b5f650ff5fae44b335879f81dc01333252"},
+    {file = "ddtrace-4.1.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b2578752c364e9b6ea78a0b878aee292b926c5a70c57c519851176cf8d66c560"},
+    {file = "ddtrace-4.1.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3d88145d8b4da5614c2552233bce213d5be86a28ba1f64a9a05e5eb5fa0ed248"},
+    {file = "ddtrace-4.1.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:35870768b72008730f40cd54d705be7753ffd114b14cf009e4b4c9da25b79966"},
+    {file = "ddtrace-4.1.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:022511f32ee607f7c2a1d9dc49285f49238f731e37c622483aa4dbb29d922bd9"},
+    {file = "ddtrace-4.1.3-cp313-cp313-win32.whl", hash = "sha256:57beb37f6d84bbae3efbfd3c28631091ebc2500f7bf82802717f05e47fdea9ac"},
+    {file = "ddtrace-4.1.3-cp313-cp313-win_amd64.whl", hash = "sha256:b4fc73ea64d2ee2e4ba590939de7433fd88024ec64b2e246082873f5c92e05b2"},
+    {file = "ddtrace-4.1.3-cp313-cp313-win_arm64.whl", hash = "sha256:3560975dbaf7c5dff8c47cf7f37bd7008aac220a9cab739cfc0d106e50309401"},
+    {file = "ddtrace-4.1.3-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:ff87421a91eea6ecd5068d8cbc6eca7d240318187ef30c7bb47a905f51eaa4d2"},
+    {file = "ddtrace-4.1.3-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:5ffe0a0908c4d9b33045e4acf51d6777ed663f5276d002329ef30e09f85c6660"},
+    {file = "ddtrace-4.1.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:57e4efbba383caec9d0731ef40ca9e2c6105259c57c5166b69d2a06adb89d8c6"},
+    {file = "ddtrace-4.1.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9837b0d32583f4b766aeee28876a72cf056ee5172dfac972e32fe9b04efcec66"},
+    {file = "ddtrace-4.1.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6ae488e3c59a7cd5b766ef51fc490ffa1ab871c320ce608107cb05cf62507a00"},
+    {file = "ddtrace-4.1.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f89997a560dc2c77faa45a9173b0d8a3bebbaba1a5f370b0c66c675fc07f179b"},
+    {file = "ddtrace-4.1.3-cp314-cp314-win32.whl", hash = "sha256:71d2288e1d640879204e53bca7b4862fd5d3445dcdc707e3feff7f40451713c0"},
+    {file = "ddtrace-4.1.3-cp314-cp314-win_amd64.whl", hash = "sha256:8c595ebec149726331437cafda763555571012b7accb0cc90330db2a51873948"},
+    {file = "ddtrace-4.1.3-cp314-cp314-win_arm64.whl", hash = "sha256:e0b64899cc56c35aed22d5d0142792f58ce23a8335c38f521e64745e8cec71f6"},
+    {file = "ddtrace-4.1.3-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:3e1c6b4fe57786cfbcbfd07ea4b05ef58fed5b1075884db34b18ec2f2e086caf"},
+    {file = "ddtrace-4.1.3-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:335065cf095318c45ff8b5540081ac7a84579ff031efbdbbd3f6e94b4d4a594c"},
+    {file = "ddtrace-4.1.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8775b4f831c9ba4d2ed3215d68712c16f0325a2fe3acb9b037f0a32ce51f1fc9"},
+    {file = "ddtrace-4.1.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:085083607bce037c912af83e954d73aafe0d5c980dfce9a5fcd8b1075759b086"},
+    {file = "ddtrace-4.1.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:3a303e2873b300e182b8c7c3dc27017e61610b6500aceb5eb149da7911bb4091"},
+    {file = "ddtrace-4.1.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:b4e1573910513938fb920db1440a9e27c627923f8160d11a13be80e7db868c0c"},
+    {file = "ddtrace-4.1.3-cp39-cp39-win32.whl", hash = "sha256:574df99b631d5a8caeb2d25cadb0ce0aa0324d9be64d2e5940216bb1734b88b0"},
+    {file = "ddtrace-4.1.3-cp39-cp39-win_amd64.whl", hash = "sha256:7fe72dee9f29bddf711578784dac70a2e06eabff44461607636dd6365fe93c46"},
+    {file = "ddtrace-4.1.3.tar.gz", hash = "sha256:d4ed70174975470e2829235ef9e056c695d7136ae7130b30e73849f91377e9b5"},
 ]
 
 [package.dependencies]
 bytecode = [
-    {version = ">=0.16.0", markers = "python_version >= \"3.13.0\""},
-    {version = ">=0.15.1", markers = "python_version ~= \"3.12.0\""},
-    {version = ">=0.14.0", markers = "python_version ~= \"3.11.0\""},
-    {version = ">=0.13.0", markers = "python_version < \"3.11.0\""},
+    {version = ">=0.13.0,<1", markers = "python_version < \"3.11\""},
+    {version = ">=0.16.0,<1", markers = "python_version >= \"3.13.0\" and python_version < \"3.14.0\""},
+    {version = ">=0.15.1,<1", markers = "python_version ~= \"3.12.0\""},
+    {version = ">=0.14.0,<1", markers = "python_version ~= \"3.11.0\""},
 ]
 envier = ">=0.6.1,<0.7.0"
-legacy-cgi = {version = ">=2.0.0", markers = "python_version >= \"3.13.0\""}
-opentelemetry-api = ">=1"
-protobuf = ">=3"
-typing_extensions = "*"
-wrapt = ">=1"
-xmltodict = ">=0.12"
+opentelemetry-api = ">=1,<2"
+wrapt = ">=1,<3"
 
 [package.extras]
-openai = ["tiktoken"]
-opentracing = ["opentracing (>=2.0.0)"]
+opentelemetry = ["opentelemetry-exporter-otlp (>=1,<2)"]
+opentracing = ["opentracing (>=2,<3)"]
 
 [[package]]
 name = "deprecated"
@@ -257,7 +336,7 @@ description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
-markers = "python_version < \"3.11.0\""
+markers = "python_version < \"3.11\""
 files = [
     {file = "exceptiongroup-1.2.0-py3-none-any.whl", hash = "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14"},
     {file = "exceptiongroup-1.2.0.tar.gz", hash = "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"},
@@ -343,19 +422,6 @@ groups = ["dev"]
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
-]
-
-[[package]]
-name = "legacy-cgi"
-version = "2.6.2"
-description = "Fork of the standard library cgi and cgitb modules, being deprecated in PEP-594"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-markers = "python_version >= \"3.13.0\""
-files = [
-    {file = "legacy_cgi-2.6.2-py3-none-any.whl", hash = "sha256:a7b83afb1baf6ebeb56522537c5943ef9813cf933f6715e88a803f7edbce0bff"},
-    {file = "legacy_cgi-2.6.2.tar.gz", hash = "sha256:9952471ceb304043b104c22d00b4f333cac27a6abe446d8a528fc437cf13c85f"},
 ]
 
 [[package]]
@@ -451,25 +517,6 @@ identify = ">=1.0.0"
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
-
-[[package]]
-name = "protobuf"
-version = "6.31.1"
-description = ""
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "protobuf-6.31.1-cp310-abi3-win32.whl", hash = "sha256:7fa17d5a29c2e04b7d90e5e32388b8bfd0e7107cd8e616feef7ed3fa6bdab5c9"},
-    {file = "protobuf-6.31.1-cp310-abi3-win_amd64.whl", hash = "sha256:426f59d2964864a1a366254fa703b8632dcec0790d8862d30034d8245e1cd447"},
-    {file = "protobuf-6.31.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:6f1227473dc43d44ed644425268eb7c2e488ae245d51c6866d19fe158e207402"},
-    {file = "protobuf-6.31.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:a40fc12b84c154884d7d4c4ebd675d5b3b5283e155f324049ae396b95ddebc39"},
-    {file = "protobuf-6.31.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:4ee898bf66f7a8b0bd21bce523814e6fbd8c6add948045ce958b73af7e8878c6"},
-    {file = "protobuf-6.31.1-cp39-cp39-win32.whl", hash = "sha256:0414e3aa5a5f3ff423828e1e6a6e907d6c65c1d5b7e6e975793d5590bdeecc16"},
-    {file = "protobuf-6.31.1-cp39-cp39-win_amd64.whl", hash = "sha256:8764cf4587791e7564051b35524b72844f845ad0bb011704c3736cce762d8fe9"},
-    {file = "protobuf-6.31.1-py3-none-any.whl", hash = "sha256:720a6c7e6b77288b85063569baae8536671b39f15cc22037ec7045658d80489e"},
-    {file = "protobuf-6.31.1.tar.gz", hash = "sha256:d8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a"},
-]
 
 [[package]]
 name = "pyproject-api"
@@ -680,7 +727,7 @@ description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
-markers = "python_version < \"3.11.0\""
+markers = "python_version < \"3.11\""
 files = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
@@ -721,6 +768,7 @@ description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version < \"3.11\""
 files = [
     {file = "typing_extensions-4.8.0-py3-none-any.whl", hash = "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0"},
     {file = "typing_extensions-4.8.0.tar.gz", hash = "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"},
@@ -850,18 +898,6 @@ files = [
 ]
 
 [[package]]
-name = "xmltodict"
-version = "0.14.2"
-description = "Makes working with XML feel like you are working with JSON"
-optional = false
-python-versions = ">=3.6"
-groups = ["main"]
-files = [
-    {file = "xmltodict-0.14.2-py2.py3-none-any.whl", hash = "sha256:20cc7d723ed729276e808f26fb6b3599f786cbc37e06c65e192ba77c40f20aac"},
-    {file = "xmltodict-0.14.2.tar.gz", hash = "sha256:201e7c28bb210e374999d1dde6382923ab0ed1a8a5faeece48ab525b7810a553"},
-]
-
-[[package]]
 name = "zipp"
 version = "3.19.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -880,4 +916,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4"
-content-hash = "3dd0cdd502953429a7c96cabc43a67b0d3eae731efebb311ac4569530033c0b6"
+content-hash = "c704ec8573f8d0c8c9a0b8431341a09637d4c8b7933e9e99387e9b811c90ad13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ django = [
     { version = ">=3,<5", python = ">=3.9,<3.10" },
     { version = ">=3,<6", python = ">=3.10,<4" },
 ]
-ddtrace = "^3.2.1"
+ddtrace = ">=3.2.1,<5"
 django-ipware = "^7.0.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/test_django_log_formatter.py
+++ b/tests/test_django_log_formatter.py
@@ -232,7 +232,7 @@ class TestASIMFormatter:
         os.environ["DD_ENV"] = "test"
         os.environ["DD_SERVICE"] = "django-service"
         os.environ["DD_VERSION"] = "1.0.0"
-        ddtrace.config = ddtrace.settings._config.Config()
+        ddtrace.config = ddtrace.internal.settings._config.Config()
 
         mock_ddtrace_span_response = MagicMock()
         mock_ddtrace_span_response.trace_id = 5735492756521486600
@@ -252,7 +252,7 @@ class TestASIMFormatter:
         os.environ.pop("DD_ENV")
         os.environ.pop("DD_SERVICE")
         os.environ.pop("DD_VERSION")
-        ddtrace.config = ddtrace.settings._config.Config()
+        ddtrace.config = ddtrace.internal.settings._config.Config()
 
     @patch("ddtrace.trace.tracer.current_span")
     def test_logs_log_datadog_required_values_when_env_vars_not_set(


### PR DESCRIPTION
Our library is compatible with ddtrace version 4 as there have been no breaking changes which affect it.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [ ] Link to ticket included (unless it's a quick out of ticket thing)
- [x] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base
